### PR TITLE
Added basic models for query and response

### DIFF
--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -1,0 +1,3 @@
+class Query < ApplicationRecord
+  has_many :response_items, inverse_of: :query
+end

--- a/app/models/response_item.rb
+++ b/app/models/response_item.rb
@@ -1,0 +1,19 @@
+class ResponseItem < ApplicationRecord
+  belongs_to :query, inverse_of: :response_items
+
+  enum source: {
+    wikipedia: 1,
+    national_library_of_israel: 2,
+    pby: 3,
+    wikidata: 4
+  }, _prefix: true
+
+  enum media_type: {
+    text: 1,
+    image: 2,
+    audio: 3,
+    video: 4
+  }, _prefix: true
+
+  validates_presence_of :query, :source, :media_type, :url
+end

--- a/db/migrate/20220902115646_create_queries.rb
+++ b/db/migrate/20220902115646_create_queries.rb
@@ -1,0 +1,8 @@
+class CreateQueries < ActiveRecord::Migration[7.0]
+  def change
+    create_table :queries do |t|
+      t.string :text, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220902115804_create_response_items.rb
+++ b/db/migrate/20220902115804_create_response_items.rb
@@ -5,6 +5,8 @@ class CreateResponseItems < ActiveRecord::Migration[7.0]
       t.integer :source, null: false
       t.integer :media_type, null: false
       t.string :url, null: false
+      t.string :media_url
+      t.string :thumbnail_url
       t.string :title
       t.text :text
       t.timestamps

--- a/db/migrate/20220902115804_create_response_items.rb
+++ b/db/migrate/20220902115804_create_response_items.rb
@@ -1,0 +1,13 @@
+class CreateResponseItems < ActiveRecord::Migration[7.0]
+  def change
+    create_table :response_items do |t|
+      t.belongs_to :query, index: true, foreign_key: true
+      t.integer :source, null: false
+      t.integer :media_type, null: false
+      t.string :url, null: false
+      t.string :title
+      t.text :text
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,33 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.0].define(version: 2022_09_02_115804) do
+  create_table "queries", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
+    t.string "text", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "response_items", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
+    t.bigint "query_id"
+    t.integer "source", null: false
+    t.integer "media_type", null: false
+    t.string "url", null: false
+    t.string "title"
+    t.text "text"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["query_id"], name: "index_response_items_on_query_id"
+  end
+
+  add_foreign_key "response_items", "queries"
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -22,6 +22,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_02_115804) do
     t.integer "source", null: false
     t.integer "media_type", null: false
     t.string "url", null: false
+    t.string "media_url"
+    t.string "thumbnail_url"
     t.string "title"
     t.text "text"
     t.datetime "created_at", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,226 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
-#   Character.create(name: "Luke", movie: movies.first)
+# This seed file should only be used in dev environment.
+# Reset db state and adds there some metadata
+ResponseItem.delete_all
+Query.delete_all
+
+q = Query.create(text: 'דוד פרישמן')
+
+ResponseItem.create(
+  query: q,
+  source: :wikipedia,
+  media_type: :text,
+  title: 'Intro paragraph',
+  text: <<~text
+    וד פרישמן (31 בדצמבר 1859, זגייז', פולין – 4 באוגוסט 1922, ברלין) היה משורר, עורך, מבקר ספרות, מתרגם, 
+     סופר, ופיליטוניסט עברי, מחלוצי הספרות העברית המודרנית. במשפטו הידוע: "מלאכת מחשבת - תחיית האומה" הביע את אמונתו
+     בצורך בחיזוק האמנות והספרות בחיי העם היהודי. מבחינה פוליטית התנגד לתנועה הציונית ולא היה שותף לעמדותיה.
+  text
+)
+
+ResponseItem.create(
+  query: q,
+  source: :national_library_of_israel,
+  media_type: :text,
+  title: 'book by F',
+  url: 'https://www.nli.org.il/he/books/NNL_ALEPH002021836/NLI'
+)
+
+ResponseItem.create(
+  query: q,
+  source: :national_library_of_israel,
+  media_type: :text,
+  title: 'book by F',
+  url: 'https://www.nli.org.il/he/books/NNL_ALEPH001179987/NLI'
+)
+
+ResponseItem.create(
+  query: q,
+  source: :national_library_of_israel,
+  media_type: :audio,
+  title: 'a text by Frischmann performed by Bertonov',
+  url: 'https://www.nli.org.il/he/items/NNL_MUSIC_AL004392683/NLI'
+)
+
+ResponseItem.create(
+  query: q,
+  source: :national_library_of_israel,
+  media_type: :image,
+  title: 'portrait of F and Bialik',
+  url: 'https://www.nli.org.il/he/archives/NNL_ARCHIVE_AL997009637569005171/NLI'
+)
+
+ResponseItem.create(
+  query: q,
+  source: :national_library_of_israel,
+  media_type: :text,
+  title: 'book by Herzl, translated by Frischmann',
+  url: 'https://www.nli.org.il/he/books/NNL_ALEPH001893335/NLI'
+)
+
+ResponseItem.create(
+  query: q,
+  source: :national_library_of_israel,
+  media_type: :text,
+  title: 'book by F',
+  url: 'https://www.nli.org.il/he/books/NNL_ALEPH002046649/NLI'
+)
+
+ResponseItem.create(
+  query: q,
+  source: :national_library_of_israel,
+  media_type: :text,
+  title: 'bilingual book by F (Hebrew-Hungarian)',
+  url: 'https://www.nli.org.il/he/books/NNL_ALEPH002195359/NLI'
+)
+
+ResponseItem.create(
+  query: q,
+  source: :national_library_of_israel,
+  media_type: :image,
+  title: 'portrait of F',
+  url: 'https://www.nli.org.il/he/archives/NNL_ARCHIVE_AL997009702799905171/NLI'
+)
+
+ResponseItem.create(
+  query: q,
+  source: :national_library_of_israel,
+  media_type: :text,
+  title: 'book by Borchardt, translated by Frischmann',
+  url: 'https://www.nli.org.il/he/books/NNL_ALEPH001839264/NLI'
+)
+
+ResponseItem.create(
+  query: q,
+  source: :national_library_of_israel,
+  media_type: :text,
+  title: 'book by Grimm, translated by F',
+  url: 'https://www.nli.org.il/he/books/NNL_ALEPH002510166/NLI'
+)
+
+ResponseItem.create(
+  query: q,
+  source: :national_library_of_israel,
+  media_type: :text,
+  title: 'book by F',
+  url: 'https://www.nli.org.il/he/books/NNL_ALEPH002701033/NLI'
+)
+
+ResponseItem.create(
+  query: q,
+  source: :national_library_of_israel,
+  media_type: :text,
+  title: 'Bible text, with comments for children by F',
+  url: 'https://www.nli.org.il/he/books/NNL_ALEPH002761068/NLI'
+)
+
+ResponseItem.create(
+  query: q,
+  source: :national_library_of_israel,
+  media_type: :text,
+  title: 'book by F',
+  url: 'https://www.nli.org.il/he/books/NNL_ALEPH002046730/NLI'
+)
+
+ResponseItem.create(
+  query: q,
+  source: :national_library_of_israel,
+  media_type: :text,
+  title: 'book by Herzl, translated by Frischmann',
+  url: 'https://www.nli.org.il/he/books/NNL_ALEPH001891192/NLI'
+)
+
+ResponseItem.create(
+  query: q,
+  source: :national_library_of_israel,
+  media_type: :text,
+  title: 'book by Herzl, translated by Frischmann',
+  url: 'https://www.nli.org.il/he/books/NNL_ALEPH001893326/NLI'
+)
+
+ResponseItem.create(
+  query: q,
+  source: :national_library_of_israel,
+  media_type: :text,
+  title: 'book by Lord Byron, translated by F',
+  url: 'https://www.nli.org.il/he/books/NNL_ALEPH001842235/NLI'
+)
+
+ResponseItem.create(
+  query: q,
+  source: :national_library_of_israel,
+  media_type: :text,
+  title: 'book by F',
+  url: 'https://www.nli.org.il/he/books/NNL_ALEPH002046823/NLI'
+)
+
+ResponseItem.create(
+  query: q,
+  source: :national_library_of_israel,
+  media_type: :text,
+  title: 'letters from F to Volfovsky',
+  url: 'https://www.nli.org.il/he/archives/NNL_ARCHIVE_AL997009756823105171/NLI'
+)
+
+ResponseItem.create(
+  query: q,
+  source: :national_library_of_israel,
+  media_type: :audio,
+  title: 'oratory by Paul Ben Haim to the text Book of Yoram by Borchardt translated by Frischmann',
+  url: 'https://www.nli.org.il/he/items/NNL_MUSIC_AL000254497/NLI'
+)
+
+ResponseItem.create(
+  query: q,
+  source: :national_library_of_israel,
+  media_type: :text,
+  title: 'letters from Ravnitsky\'s archive. Some by or to F and others',
+  url: 'https://www.nli.org.il/he/archives/NNL_ARCHIVE_AL003436586/NLI'
+)
+
+ResponseItem.create(
+  query: q,
+  source: :national_library_of_israel,
+  media_type: :audio,
+  title: 'recorded songs; the lyrics to one are by F',
+  url: 'https://www.nli.org.il/he/items/NNL_MUSIC_AL000229686/NLI'
+)
+
+ResponseItem.create(
+  query: q,
+  source: :national_library_of_israel,
+  media_type: :audio,
+  title: 'recorded songs; the lyrics to one are by F',
+  url: 'https://www.nli.org.il/he/items/NNL_MUSIC_AL000232275/NLI'
+)
+
+ResponseItem.create(
+  query: q,
+  source: :pby,
+  media_type: :text,
+  title: 'main page about Frischmann, linking to all his works in PBY, as well as (in sidebar), works *about* F',
+  url: 'https://benyehuda.org/author/142'
+)
+
+ResponseItem.create(
+  query: q,
+  source: :pby,
+  media_type: :text,
+  title: 'first work in the page; all the rest of the works have similar URLs.  They are grouped by genre on the author page. Within each genre, some are grouped by book title',
+  url: 'https://benyehuda.org/read/10874'
+)
+
+ResponseItem.create(
+  query: q,
+  source: :pby,
+  media_type: :text,
+  title: 'first work about F in F\'s page.',
+  url: 'https://benyehuda.org/work/show/3350'
+)
+
+ResponseItem.create(
+  query: q,
+  source: :pby,
+  media_type: :image,
+  title: 'Profile illustation',
+  url: 'https://s3.amazonaws.com/bybeprod/people/profile_images/000/000/142/thumb/Frishman_David_LR.jpg?1625869858'
+)

--- a/spec/factories/queries.rb
+++ b/spec/factories/queries.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :query do
+    text { "MyString" }
+  end
+end

--- a/spec/factories/response_items.rb
+++ b/spec/factories/response_items.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :response_item do
+    source { 1 }
+    index { 1 }
+    url { "MyString" }
+    picture_url { "MyString" }
+  end
+end

--- a/spec/models/query_spec.rb
+++ b/spec/models/query_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Query, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/response_item_spec.rb
+++ b/spec/models/response_item_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ResponseItem, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
This PR adds two models:

Query, representying search query performed by user

ResponseItem representing single response item, it can be either text, audio, image or video file.

I've added some demo data to seeds.rb: just run `rails db:seed` to populate them in your db. Data was taken from spreadsheet you've provided.

I see those table to be used as follows:
1) user enters search query and it is stored in Queries table
2) system queries different sources and populates ResponseItems table
3) system renders output using data from ResponseItems table

For POC we can avoid step 2) for now and use pre-populated data.

I did not used Wikidata records for now, because I feel we may need different data model for them



