### PR TITLE
Temporarily disabled Amazon S3 in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,7 +86,7 @@ group :development, :test do
 end
 
 group :production do
-  gem "aws-sdk-s3"
+  # gem "aws-sdk-s3"
 end
 
 group :production, :development do

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -37,8 +37,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for Apache
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
-  # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :amazon
+  config.active_storage.service = :test # :amazon Temporary switched to test storage for production
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil


### PR DESCRIPTION
We don't use Active Storage yet, so to simplify productions setup, I've switched ActiveStorage to use file system in production.
We should switch it back when we'll need ActiveStorage