### PR TITLE
Added basic search providers.

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,6 @@
 DATABASE_URL=mysql2://root:mysql@127.0.0.1:3306/sara_development
 MEMCACHE_SERVERS=127.0.0.1:11211
-S3_ACCESS_KEY_ID=<SET VALUE>
-S3_SECRET_ACCESS_KEY=<SET VALUE>
-S3_STORAGE_BUCKET=<SET VALUE>
+S3_ACCESS_KEY_ID=<set value in .env.development.local file>
+S3_SECRET_ACCESS_KEY=<set value in .env.development.local file>
+S3_STORAGE_BUCKET=<set value in .env.development.local file>
+PBY_API_KEY=<set value in .env.development.local file>

--- a/Gemfile
+++ b/Gemfile
@@ -46,12 +46,15 @@ gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
 gem "bootsnap", require: false
 
 gem 'sparql-client' # for querying Wikidata with SPARQL
-gem 'rest-client' # for searching Wikidata's Elasticsearch index
+gem "rest-client", "~> 2.1"
+
 # Use Sass to process CSS
 # gem "sassc-rails"
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
+
+
 
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]

--- a/Gemfile
+++ b/Gemfile
@@ -54,8 +54,6 @@ gem "rest-client", "~> 2.1"
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
-
-
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,22 +69,6 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
-    aws-eventstream (1.2.0)
-    aws-partitions (1.614.0)
-    aws-sdk-core (3.131.6)
-      aws-eventstream (~> 1, >= 1.0.2)
-      aws-partitions (~> 1, >= 1.525.0)
-      aws-sigv4 (~> 1.1)
-      jmespath (~> 1, >= 1.6.1)
-    aws-sdk-kms (1.58.0)
-      aws-sdk-core (~> 3, >= 3.127.0)
-      aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.114.0)
-      aws-sdk-core (~> 3, >= 3.127.0)
-      aws-sdk-kms (~> 1)
-      aws-sigv4 (~> 1.4)
-    aws-sigv4 (1.5.1)
-      aws-eventstream (~> 1, >= 1.0.2)
     bindex (0.8.1)
     bootsnap (1.13.0)
       msgpack (~> 1.2)
@@ -141,7 +125,6 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
-    jmespath (1.6.1)
     jsbundling-rails (1.0.3)
       railties (>= 6.0.0)
     json (2.6.2)
@@ -314,7 +297,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  aws-sdk-s3
   bootsnap
   byebug
   capybara
@@ -330,7 +312,7 @@ DEPENDENCIES
   mysql2
   puma (~> 5.0)
   rails (~> 7.0, >= 7.0.3.1)
-  rest-client
+  rest-client (~> 2.1)
   rspec-rails
   rubocop
   selenium-webdriver

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ In Ubuntu
     nvm use lts/gallium
     ```
    You may need to close and reopen terminal window after nvm installation
+
 3. Install proper version of yarn package manager:
    ```
    npm install yarn --global
@@ -25,7 +26,13 @@ In Ubuntu
    ```
    yarn set version berry
    ```
-   
+
+   Configure yarn to use node-modules linker instead of PnP linker 
+   (Damir: I did not found other way to make cssbundling gem to work properly): 
+   ```
+   yarn config set nodeLinker node-modules
+   ```
+
    ensure that yarn have version >= 3.x:
    ```
    yarn --version

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ In Ubuntu
 2. Install proper NodeJS version, we recommend using [NVM](https://github.com/nvm-sh/nvm):
     ```
     nvm install lts/gallium
-    nvm use 16.17.0
+    nvm use lts/gallium
     ```
    You may need to close and reopen terminal window after nvm installation
 3. Install proper version of yarn package manager:
@@ -26,7 +26,7 @@ In Ubuntu
    yarn set version berry
    ```
    
-   ensure that yarn have version > 3.x:
+   ensure that yarn have version >= 3.x:
    ```
    yarn --version
    ```

--- a/app/controllers/queries_controller.rb
+++ b/app/controllers/queries_controller.rb
@@ -1,0 +1,24 @@
+class QueriesController < ApplicationController
+  def create
+    text = params.require(:query).permit(:text)[:text].squish
+    q = Query.find_by(text: text)
+    if q.nil?
+      q = Query.create!(text: text)
+    end
+    SearchService.call(q)
+
+    redirect_to q
+  end
+
+  def show
+    @query = Query.find(params[:id])
+  end
+
+  def index
+    @records = Query.select(:id, :created_at, :text)
+                    .select('count(*) as responses_quantity')
+                    .left_joins(:response_items)
+                    .group(Arel.sql('queries.id'))
+                    .order(:created_at)
+  end
+end

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -1,3 +1,4 @@
 class Query < ApplicationRecord
+  validates :text, presence: true
   has_many :response_items, inverse_of: :query
 end

--- a/app/models/response_item.rb
+++ b/app/models/response_item.rb
@@ -3,7 +3,7 @@ class ResponseItem < ApplicationRecord
 
   enum source: {
     wikipedia: 1,
-    national_library_of_israel: 2,
+    nli: 2,
     pby: 3,
     wikidata: 4
   }, _prefix: true

--- a/app/models/response_item.rb
+++ b/app/models/response_item.rb
@@ -15,5 +15,5 @@ class ResponseItem < ApplicationRecord
     video: 4
   }, _prefix: true
 
-  validates_presence_of :query, :source, :media_type, :url
+  validates_presence_of :query, :source, :media_type, :url, :index
 end

--- a/app/services/application_service.rb
+++ b/app/services/application_service.rb
@@ -1,0 +1,8 @@
+# Base class for all service
+# Exposes class method 'call', which creates new instance of service object and calls it with provided arguments.
+# So instead of 'MyService.new.call(x, y)' we can use 'MyService.call(x, y)'
+class ApplicationService
+  def self.call(*args, &block)
+    new.call(*args, &block)
+  end
+end

--- a/app/services/search/nli_search_provider.rb
+++ b/app/services/search/nli_search_provider.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Search
+  class NliSearchProvider < ApplicationService
+    NLI_API_KEY = ENV['NLI_API_KEY']
+    NLI_SEARCH_API_URL = 'https://api.nli.org.il/openlibrary/search'
+
+    def call(query)
+      # see https://www.nli.org.il/en/research-and-teach/open-library/search-api
+      response = RestClient::Request.execute(
+        method: :get,
+        url: NLI_SEARCH_API_URL,
+        verify_ssl: false,
+        headers: {
+          params: {
+            api_key: NLI_API_KEY,
+            query: "any,contains,#{query}"
+          },
+          content_type: :json
+        }
+      )
+      JSON.parse(response).map do |item|
+        Search::ResponseItem.new(
+          url: item['@id'],
+          thumbnail_url: property_value(item, 'thumbnail'),
+          external_id: item['http://purl.org/dc/elements/1.1/recordid'],
+          title: "#{property_value(item, 'creator')} / #{property_value(item, 'title')}",
+          media_type: :text,
+          media_url: property_value(item, 'download'),
+          text: property_value(item, 'format')
+        )
+      end
+    end
+
+    def source
+      return :nli
+    end
+
+    private
+    def property_value(item, property)
+      val = item["http://purl.org/dc/elements/1.1/#{property}"]&.first
+      return val.present? ? val['@value'] : nil
+    end
+  end
+end

--- a/app/services/search/pby_search_provider.rb
+++ b/app/services/search/pby_search_provider.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Search
+  class PbySearchProvider < ApplicationService
+    PBY_SEARCH_API_URL = 'https://benyehuda.org/api/v1/search'
+
+    PBY_API_KEY = ENV['PBY_API_KEY']
+
+    # see https://benyehuda.org/api-docs/index.html#operations-tag-search
+    def call(query)
+      page = 1
+      result = []
+      begin
+        response = RestClient.post(
+          PBY_SEARCH_API_URL,
+          {
+            key: PBY_API_KEY,
+            view: :basic,
+            snippet: true,
+            fulltext: query,
+            page: page,
+          }.to_json,
+          { content_type: :json }
+        )
+        response = JSON.parse(response)
+        total = response['total_count']
+        result += response['data'].map do |rec|
+          metadata = rec['metadata']
+          Search::ResponseItem.new(
+            title: metadata['title'],
+            media_url: metadata['url'],
+            media_type: :text,
+            url: rec['url'],
+            text: rec['snippet'],
+            external_id: rec['id']
+          )
+        end
+        page += 1
+      end while result.size < total && page < 5 # limit search to first 100 texts only
+      return result
+    end
+
+    def source
+      return :pby
+    end
+  end
+end

--- a/app/services/search/response_item.rb
+++ b/app/services/search/response_item.rb
@@ -1,0 +1,8 @@
+# Simple model to represent single item in search query response
+module Search
+  class ResponseItem
+    include ActiveModel::API
+    include ActiveModel::Attributes
+    attr_accessor :title, :media_url, :thumbnail_url, :media_type, :url, :text, :external_id
+  end
+end

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -1,0 +1,28 @@
+class SearchService < ApplicationService
+  PROVIDERS = [Search::PbySearchProvider]
+
+  def call(query)
+    PROVIDERS.each do|klass|
+      provider = klass.new
+      items = provider.call(query.text)
+      source = provider.source
+
+      Query.transaction do
+        query.response_items.where(source: source).delete_all
+        items.each_with_index do |item, index|
+          query.response_items.create!(
+            source: source,
+            index: index,
+            title: item.title,
+            media_url: item.media_url,
+            thumbnail_url: item.thumbnail_url,
+            media_type: item.media_type,
+            url: item.url,
+            text: item.text,
+            external_id: item.external_id
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -1,5 +1,5 @@
 class SearchService < ApplicationService
-  PROVIDERS = [Search::PbySearchProvider]
+  PROVIDERS = [Search::PbySearchProvider, Search::NliSearchProvider]
 
   def call(query)
     PROVIDERS.each do|klass|
@@ -13,7 +13,7 @@ class SearchService < ApplicationService
           query.response_items.create!(
             source: source,
             index: index,
-            title: item.title,
+            title: item.title[0..100],
             media_url: item.media_url,
             thumbnail_url: item.thumbnail_url,
             media_type: item.media_type,

--- a/app/views/queries/index.html.haml
+++ b/app/views/queries/index.html.haml
@@ -1,0 +1,23 @@
+%h1= t('.header')
+
+= form_for(Query.new) do |f|
+  .row
+    .col-sm-3
+    .col-sm-1
+      = f.label t('.create_new'), class: 'form-label'
+    .col-sm-4
+      = f.text_field :text, placeholder: true, class: 'form-control'
+    .col-sm-2
+      = f.submit t('.run'), class: 'btn btn-primary'
+
+%table.table
+  %thead
+    %th= t('activerecord.attributes.default.created_at')
+    %th= t('activerecord.attributes.query.text')
+    %th= t('.responses_quantity')
+  %tbody
+    - @records.each do |q|
+      %tr
+        %td= q.created_at
+        %td= link_to q.text, q
+        %td= q.responses_quantity

--- a/app/views/queries/show.html.haml
+++ b/app/views/queries/show.html.haml
@@ -9,5 +9,5 @@
             = image_tag item.thumbnail_url, alt: item.title
           .card-body
             %h5.card-title
-              = link_to item.title, item.url
+              = link_to item.title, item.url, target: :blank
             %p.card-text= item.text

--- a/app/views/queries/show.html.haml
+++ b/app/views/queries/show.html.haml
@@ -1,0 +1,13 @@
+%h1= t('.header', query_text: @query.text)
+- @query.response_items.to_a.group_by(&:source).each do |source, items|
+  %h2= t("activerecord.attributes.response_item.sources.#{source}")
+  .row
+    - items.each do |item|
+      .col-lg-2.col-sm-3
+        .card
+          - if item.thumbnail_url.present?
+            = image_tag item.thumbnail_url, alt: item.title
+          .card-body
+            %h5.card-title
+              = link_to item.title, item.url
+            %p.card-text= item.text

--- a/app/views/welcome/index.html.haml
+++ b/app/views/welcome/index.html.haml
@@ -2,9 +2,10 @@
 %ul
   %li
     %h3
-      %a{href: search_path}
-        = t(:focused_search)
+      = link_to t('nav.focused_search'), search_path
   %li
     %h3
-      %a{href: suggest_path}
-        = t(:suggest_topics)
+      = link_to t('nav.suggest_topics'), suggest_path
+  %li
+    %h3
+      = link_to t('nav.stored_queries'), queries_path

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -1,0 +1,17 @@
+en:
+  activerecord:
+    models:
+      query: Search Query
+      response_item: Response Item
+    attributes:
+      default:
+        created_at: Created At
+        updated_at: Updated At
+      query:
+        text: Query Text
+      response_item:
+        sources:
+          pby: "Project Ben Yehuda"
+          nli: "National Library of Israel"
+          wikipedia: "Wikipedia"
+          wikidata: "WikiData"

--- a/config/locales/activerecord.he.yml
+++ b/config/locales/activerecord.he.yml
@@ -1,0 +1,17 @@
+he:
+  activerecord:
+    models:
+      query: Search Query
+      response_item: Response Item
+    attributes:
+      default:
+        created_at: Created At
+        updated_at: Updated At
+      query:
+        text: Query Text
+      response_item:
+        sources:
+          pby: "Project Ben Yehuda"
+          nli: "National Library of Israel"
+          wikipedia: "Wikipedia"
+          wikidata: "WikiData"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,33 +1,13 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t "hello"
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t("hello") %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   "true": "foo"
-#
-# To learn more, please read the Rails Internationalization guide
-# available at https://guides.rubyonrails.org/i18n.html.
-
 en:
-  hello: "Hello world"
+  nav:
+    focused_search: Focused Search
+    suggest_topics: Suggested Topics
+    stored_queries: Stored Queries
+  queries:
+    index:
+      header: Stored Search Queries
+      responses_quantity: Responses Quantity
+      create_new: New Search
+      run: Run
+    show:
+      header: "Found results for query: '%{query_text}'"

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -30,8 +30,18 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 he:
-  focused_search: חיפוש ממוקד
-  suggest_topics: הצעות לנושאים
+  nav:
+    focused_search: חיפוש ממוקד
+    suggest_topics: הצעות לנושאים
+    stored_queries: Stored Queries
+  queries:
+    index:
+      header: Stored Search Queries
+      responses_quantity: Responses Quantity
+      create_new: New Search
+      run: Run
+    show:
+      header: "Found results for query: '%{query_text}'"
   databases: מאגרי מידע
   data_items: פריטי מידע
   about_8_million: כ־8 מליון

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,6 @@ Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")
-  # root "articles#index"
   root 'welcome#index'
 
   resource :welcome, only: :index
@@ -11,6 +10,9 @@ Rails.application.routes.draw do
   match 'welcome/search', as: 'search', via: [:get, :post]
   match 'welcome/suggest', as: 'suggest', via: [:get, :post]
   match 'welcome/search_disambig', as: 'search_disambig', via: [:get, :post]
+
+  resources :queries, only: [:index, :create, :show]
+
   resources :timelines, only: :index do
     collection do
       get :data

--- a/db/migrate/20221012105225_add_external_id_to_response_items.rb
+++ b/db/migrate/20221012105225_add_external_id_to_response_items.rb
@@ -1,0 +1,5 @@
+class AddExternalIdToResponseItems < ActiveRecord::Migration[7.0]
+  def change
+    add_column :response_items, :external_id, :string
+  end
+end

--- a/db/migrate/20221013191923_add_index_to_response_items.rb
+++ b/db/migrate/20221013191923_add_index_to_response_items.rb
@@ -1,0 +1,5 @@
+class AddIndexToResponseItems < ActiveRecord::Migration[7.0]
+  def change
+    add_column :response_items, :index, :integer, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_02_115804) do
-  create_table "queries", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+ActiveRecord::Schema[7.0].define(version: 2022_10_13_191923) do
+  create_table "queries", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.string "text", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "response_items", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+  create_table "response_items", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.bigint "query_id"
     t.integer "source", null: false
     t.integer "media_type", null: false
@@ -28,6 +28,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_02_115804) do
     t.text "text"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "external_id"
+    t.integer "index", null: false
     t.index ["query_id"], name: "index_response_items_on_query_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,11 +5,14 @@ Query.delete_all
 
 q = Query.create(text: 'דוד פרישמן')
 
+idx = 0
+
 ResponseItem.create(
   query: q,
   source: :wikipedia,
   media_type: :text,
   title: 'Intro paragraph',
+  index: ++idx,
   text: <<~text
     וד פרישמן (31 בדצמבר 1859, זגייז', פולין – 4 באוגוסט 1922, ברלין) היה משורר, עורך, מבקר ספרות, מתרגם, 
      סופר, ופיליטוניסט עברי, מחלוצי הספרות העברית המודרנית. במשפטו הידוע: "מלאכת מחשבת - תחיית האומה" הביע את אמונתו
@@ -22,7 +25,8 @@ ResponseItem.create(
   source: :national_library_of_israel,
   media_type: :text,
   title: 'book by F',
-  url: 'https://www.nli.org.il/he/books/NNL_ALEPH002021836/NLI'
+  url: 'https://www.nli.org.il/he/books/NNL_ALEPH002021836/NLI',
+  index: ++idx
 )
 
 ResponseItem.create(
@@ -30,7 +34,8 @@ ResponseItem.create(
   source: :national_library_of_israel,
   media_type: :text,
   title: 'book by F',
-  url: 'https://www.nli.org.il/he/books/NNL_ALEPH001179987/NLI'
+  url: 'https://www.nli.org.il/he/books/NNL_ALEPH001179987/NLI',
+  index: ++idx
 )
 
 ResponseItem.create(
@@ -38,7 +43,8 @@ ResponseItem.create(
   source: :national_library_of_israel,
   media_type: :audio,
   title: 'a text by Frischmann performed by Bertonov',
-  url: 'https://www.nli.org.il/he/items/NNL_MUSIC_AL004392683/NLI'
+  url: 'https://www.nli.org.il/he/items/NNL_MUSIC_AL004392683/NLI',
+  index: ++idx
 )
 
 ResponseItem.create(
@@ -46,7 +52,8 @@ ResponseItem.create(
   source: :national_library_of_israel,
   media_type: :image,
   title: 'portrait of F and Bialik',
-  url: 'https://www.nli.org.il/he/archives/NNL_ARCHIVE_AL997009637569005171/NLI'
+  url: 'https://www.nli.org.il/he/archives/NNL_ARCHIVE_AL997009637569005171/NLI',
+  index: ++idx
 )
 
 ResponseItem.create(
@@ -54,7 +61,8 @@ ResponseItem.create(
   source: :national_library_of_israel,
   media_type: :text,
   title: 'book by Herzl, translated by Frischmann',
-  url: 'https://www.nli.org.il/he/books/NNL_ALEPH001893335/NLI'
+  url: 'https://www.nli.org.il/he/books/NNL_ALEPH001893335/NLI',
+  index: ++idx
 )
 
 ResponseItem.create(
@@ -62,7 +70,8 @@ ResponseItem.create(
   source: :national_library_of_israel,
   media_type: :text,
   title: 'book by F',
-  url: 'https://www.nli.org.il/he/books/NNL_ALEPH002046649/NLI'
+  url: 'https://www.nli.org.il/he/books/NNL_ALEPH002046649/NLI',
+  index: ++idx
 )
 
 ResponseItem.create(
@@ -70,7 +79,8 @@ ResponseItem.create(
   source: :national_library_of_israel,
   media_type: :text,
   title: 'bilingual book by F (Hebrew-Hungarian)',
-  url: 'https://www.nli.org.il/he/books/NNL_ALEPH002195359/NLI'
+  url: 'https://www.nli.org.il/he/books/NNL_ALEPH002195359/NLI',
+  index: ++idx
 )
 
 ResponseItem.create(
@@ -78,7 +88,8 @@ ResponseItem.create(
   source: :national_library_of_israel,
   media_type: :image,
   title: 'portrait of F',
-  url: 'https://www.nli.org.il/he/archives/NNL_ARCHIVE_AL997009702799905171/NLI'
+  url: 'https://www.nli.org.il/he/archives/NNL_ARCHIVE_AL997009702799905171/NLI',
+  index: ++idx
 )
 
 ResponseItem.create(
@@ -86,7 +97,8 @@ ResponseItem.create(
   source: :national_library_of_israel,
   media_type: :text,
   title: 'book by Borchardt, translated by Frischmann',
-  url: 'https://www.nli.org.il/he/books/NNL_ALEPH001839264/NLI'
+  url: 'https://www.nli.org.il/he/books/NNL_ALEPH001839264/NLI',
+  index: ++idx
 )
 
 ResponseItem.create(
@@ -94,7 +106,8 @@ ResponseItem.create(
   source: :national_library_of_israel,
   media_type: :text,
   title: 'book by Grimm, translated by F',
-  url: 'https://www.nli.org.il/he/books/NNL_ALEPH002510166/NLI'
+  url: 'https://www.nli.org.il/he/books/NNL_ALEPH002510166/NLI',
+  index: ++idx
 )
 
 ResponseItem.create(
@@ -102,7 +115,8 @@ ResponseItem.create(
   source: :national_library_of_israel,
   media_type: :text,
   title: 'book by F',
-  url: 'https://www.nli.org.il/he/books/NNL_ALEPH002701033/NLI'
+  url: 'https://www.nli.org.il/he/books/NNL_ALEPH002701033/NLI',
+  index: ++idx
 )
 
 ResponseItem.create(
@@ -110,7 +124,8 @@ ResponseItem.create(
   source: :national_library_of_israel,
   media_type: :text,
   title: 'Bible text, with comments for children by F',
-  url: 'https://www.nli.org.il/he/books/NNL_ALEPH002761068/NLI'
+  url: 'https://www.nli.org.il/he/books/NNL_ALEPH002761068/NLI',
+  index: ++idx
 )
 
 ResponseItem.create(
@@ -118,7 +133,8 @@ ResponseItem.create(
   source: :national_library_of_israel,
   media_type: :text,
   title: 'book by F',
-  url: 'https://www.nli.org.il/he/books/NNL_ALEPH002046730/NLI'
+  url: 'https://www.nli.org.il/he/books/NNL_ALEPH002046730/NLI',
+  index: ++idx
 )
 
 ResponseItem.create(
@@ -126,7 +142,8 @@ ResponseItem.create(
   source: :national_library_of_israel,
   media_type: :text,
   title: 'book by Herzl, translated by Frischmann',
-  url: 'https://www.nli.org.il/he/books/NNL_ALEPH001891192/NLI'
+  url: 'https://www.nli.org.il/he/books/NNL_ALEPH001891192/NLI',
+  index: ++idx
 )
 
 ResponseItem.create(
@@ -134,7 +151,8 @@ ResponseItem.create(
   source: :national_library_of_israel,
   media_type: :text,
   title: 'book by Herzl, translated by Frischmann',
-  url: 'https://www.nli.org.il/he/books/NNL_ALEPH001893326/NLI'
+  url: 'https://www.nli.org.il/he/books/NNL_ALEPH001893326/NLI',
+  index: ++idx
 )
 
 ResponseItem.create(
@@ -142,7 +160,8 @@ ResponseItem.create(
   source: :national_library_of_israel,
   media_type: :text,
   title: 'book by Lord Byron, translated by F',
-  url: 'https://www.nli.org.il/he/books/NNL_ALEPH001842235/NLI'
+  url: 'https://www.nli.org.il/he/books/NNL_ALEPH001842235/NLI',
+  index: ++idx
 )
 
 ResponseItem.create(
@@ -150,7 +169,8 @@ ResponseItem.create(
   source: :national_library_of_israel,
   media_type: :text,
   title: 'book by F',
-  url: 'https://www.nli.org.il/he/books/NNL_ALEPH002046823/NLI'
+  url: 'https://www.nli.org.il/he/books/NNL_ALEPH002046823/NLI',
+  index: ++idx
 )
 
 ResponseItem.create(
@@ -158,7 +178,8 @@ ResponseItem.create(
   source: :national_library_of_israel,
   media_type: :text,
   title: 'letters from F to Volfovsky',
-  url: 'https://www.nli.org.il/he/archives/NNL_ARCHIVE_AL997009756823105171/NLI'
+  url: 'https://www.nli.org.il/he/archives/NNL_ARCHIVE_AL997009756823105171/NLI',
+  index: ++idx
 )
 
 ResponseItem.create(
@@ -166,7 +187,8 @@ ResponseItem.create(
   source: :national_library_of_israel,
   media_type: :audio,
   title: 'oratory by Paul Ben Haim to the text Book of Yoram by Borchardt translated by Frischmann',
-  url: 'https://www.nli.org.il/he/items/NNL_MUSIC_AL000254497/NLI'
+  url: 'https://www.nli.org.il/he/items/NNL_MUSIC_AL000254497/NLI',
+  index: ++idx
 )
 
 ResponseItem.create(
@@ -174,7 +196,8 @@ ResponseItem.create(
   source: :national_library_of_israel,
   media_type: :text,
   title: 'letters from Ravnitsky\'s archive. Some by or to F and others',
-  url: 'https://www.nli.org.il/he/archives/NNL_ARCHIVE_AL003436586/NLI'
+  url: 'https://www.nli.org.il/he/archives/NNL_ARCHIVE_AL003436586/NLI',
+  index: ++idx
 )
 
 ResponseItem.create(
@@ -182,7 +205,8 @@ ResponseItem.create(
   source: :national_library_of_israel,
   media_type: :audio,
   title: 'recorded songs; the lyrics to one are by F',
-  url: 'https://www.nli.org.il/he/items/NNL_MUSIC_AL000229686/NLI'
+  url: 'https://www.nli.org.il/he/items/NNL_MUSIC_AL000229686/NLI',
+  index: ++idx
 )
 
 ResponseItem.create(
@@ -190,7 +214,8 @@ ResponseItem.create(
   source: :national_library_of_israel,
   media_type: :audio,
   title: 'recorded songs; the lyrics to one are by F',
-  url: 'https://www.nli.org.il/he/items/NNL_MUSIC_AL000232275/NLI'
+  url: 'https://www.nli.org.il/he/items/NNL_MUSIC_AL000232275/NLI',
+  index: ++idx
 )
 
 ResponseItem.create(
@@ -198,7 +223,8 @@ ResponseItem.create(
   source: :pby,
   media_type: :text,
   title: 'main page about Frischmann, linking to all his works in PBY, as well as (in sidebar), works *about* F',
-  url: 'https://benyehuda.org/author/142'
+  url: 'https://benyehuda.org/author/142',
+  index: ++idx
 )
 
 ResponseItem.create(
@@ -206,7 +232,8 @@ ResponseItem.create(
   source: :pby,
   media_type: :text,
   title: 'first work in the page; all the rest of the works have similar URLs.  They are grouped by genre on the author page. Within each genre, some are grouped by book title',
-  url: 'https://benyehuda.org/read/10874'
+  url: 'https://benyehuda.org/read/10874',
+  index: ++idx
 )
 
 ResponseItem.create(
@@ -214,7 +241,8 @@ ResponseItem.create(
   source: :pby,
   media_type: :text,
   title: 'first work about F in F\'s page.',
-  url: 'https://benyehuda.org/work/show/3350'
+  url: 'https://benyehuda.org/work/show/3350',
+  index: ++idx
 )
 
 ResponseItem.create(
@@ -222,5 +250,6 @@ ResponseItem.create(
   source: :pby,
   media_type: :image,
   title: 'Profile illustation',
-  url: 'https://s3.amazonaws.com/bybeprod/people/profile_images/000/000/142/thumb/Frishman_David_LR.jpg?1625869858'
+  url: 'https://s3.amazonaws.com/bybeprod/people/profile_images/000/000/142/thumb/Frishman_David_LR.jpg?1625869858',
+  index: ++idx
 )

--- a/spec/controllers/queries_controller_spec.rb
+++ b/spec/controllers/queries_controller_spec.rb
@@ -16,6 +16,7 @@ describe QueriesController do
 
       before do
         expect_any_instance_of(Search::PbySearchProvider).to receive(:call).and_return(build_list(:search_response_item, 5))
+        expect_any_instance_of(Search::NliSearchProvider).to receive(:call).and_return(build_list(:search_response_item, 3))
       end
 
       it 'creates new Query record' do
@@ -24,6 +25,7 @@ describe QueriesController do
 
         expect(q).to have_attributes(text: 'New Query')
         expect(q.response_items.source_pby.count).to eq 5
+        expect(q.response_items.source_nli.count).to eq 3
       end
     end
   end

--- a/spec/controllers/queries_controller_spec.rb
+++ b/spec/controllers/queries_controller_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+describe QueriesController do
+  describe 'Collection Actions' do
+    before do
+      create_list(:query, 5)
+    end
+
+    describe '#index' do
+      subject! { get :index }
+      it { is_expected.to be_successful }
+    end
+
+    describe '#create' do
+      subject(:call) { post :create, params: { query: { text: 'New Query' } } }
+
+      before do
+        expect_any_instance_of(Search::PbySearchProvider).to receive(:call).and_return(build_list(:search_response_item, 5))
+      end
+
+      it 'creates new Query record' do
+        expect { call }.to change { Query.count }.by(1)
+        q = Query.order(id: :desc).first
+
+        expect(q).to have_attributes(text: 'New Query')
+        expect(q.response_items.source_pby.count).to eq 5
+      end
+    end
+  end
+
+  describe 'Member Actions' do
+    let! (:query) { create(:query) }
+
+    describe '#show' do
+      subject { get :show, params: { id: query.id }}
+
+      it {
+        is_expected.to be_successful
+      }
+    end
+  end
+
+end

--- a/spec/factories/queries.rb
+++ b/spec/factories/queries.rb
@@ -1,5 +1,14 @@
 FactoryBot.define do
   factory :query do
-    text { "MyString" }
+    text { Faker::Name.name }
+
+    transient do
+      response_items { build_list(:response_item, 5) }
+    end
+
+    after(:create) do |query, evaluator|
+      query.response_items << evaluator.response_items
+      query.save!
+    end
   end
 end

--- a/spec/factories/search/response_items.rb
+++ b/spec/factories/search/response_items.rb
@@ -1,9 +1,6 @@
 FactoryBot.define do
-  factory :response_item do
-    query
-    source { ResponseItem.sources.keys.sample }
+  factory :search_response_item, class: Search::ResponseItem do
     media_type { ResponseItem.media_types.keys.sample }
-    index { (query.response_items.map(&:index).max || 0) + 1 }
     url { Faker::Internet.url }
     thumbnail_url { Faker::Internet.url }
     title { Faker::Book.title }

--- a/spec/models/query_spec.rb
+++ b/spec/models/query_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
-RSpec.describe Query, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+describe Query do
+
 end

--- a/spec/models/response_item_spec.rb
+++ b/spec/models/response_item_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
-RSpec.describe ResponseItem, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+describe ResponseItem do
+
 end

--- a/spec/requests/timeline_spec.rb
+++ b/spec/requests/timeline_spec.rb
@@ -2,6 +2,10 @@ require 'rails_helper'
 
 RSpec.describe "Timelines", type: :request do
   describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+    subject! { get '/timelines' }
+
+    it 'completes successfully' do
+      expect(response).to have_http_status(:ok)
+    end
   end
 end


### PR DESCRIPTION
Initial version of PBY and NLI search providers.

There is a new page /queries where you can see stored queries and execute new ones.
After new query is done you'll be redirected to query results page.

Note: one of the issues I have now is that I cannot easily say from NLI response what is the format of item: if this a text or image or audio, etc. E.g. for picture it can be something like '1 photograph : color ; 35 mm..', for audio something like 'audio disc (66 minutes) : digital ; 4 3/4 in. + 1 booklet (31 pages ; 12 cm.)'. We need some way to parse such entry

I used english for UI but all strings are internationalized and I've added english versions to hebrew localization files. So you just need to translate them.

Also I've used grouping in i18n files, so all resources are grouped by controller/action sections. It allows to more easily manage i18n resources in future. Rails automatically adds controller and action names to string resources, when calling 't('something')' from view. So in view page all keys will be shorter.

I would propose to use this approach for future.

Also I've added stubs for ActiveRecord i18n. Using such files we can translate many system messages, like errors, etc. Also many Rails tools, like form-builders can use resources for ActiveRecord i18n files. So it would be good to translate all our models in such a way.

