### PR TITLE
Favorite items

### DIFF
--- a/app/controllers/queries_controller.rb
+++ b/app/controllers/queries_controller.rb
@@ -28,6 +28,16 @@ class QueriesController < ApplicationController
     @items = @items.merge(ResponseItem.where('item_date <= ?', @todate)) if @todate.present?
   end
 
+  def destroy
+    # we should keep favorite items even if query is destroed
+    # so at first we delete all non-favorite items
+    @query.response_items.where(favorite: false).delete_all
+
+    @query.response_items.update_all(query_id: nil)
+    @query.destroy!
+    redirect_to @query.project, alert: t('.success')
+  end
+
   def set_models
     project_id = params[:project_id]
     if project_id.present?

--- a/app/controllers/response_items_controller.rb
+++ b/app/controllers/response_items_controller.rb
@@ -1,0 +1,20 @@
+class ResponseItemsController < ApplicationController
+  before_action :set_model, only: [ :toggle_favorite ]
+
+  def toggle_favorite
+    # We may have same external item returned by several queries inside same project.
+    # So we need to update all of them
+    # TODO: refactor system to avoid items duplication
+    @response_item.project.response_items.
+      where(source: @response_item.source, external_id: @response_item.external_id).
+      update_all(favorite: params[:value])
+
+    head :ok
+  end
+
+  private
+
+  def set_model
+    @response_item = ResponseItem.find(params[:id])
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,5 +1,30 @@
 class Project < ApplicationRecord
+  has_many :response_items, inverse_of: :project, dependent: :destroy
   has_many :queries, inverse_of: :project, dependent: :destroy
   has_many :ignored_items, inverse_of: :project, dependent: :destroy
   validates :title, presence: true
+
+  def favorite_items
+    # We can have duplicates of favorite items in db (if same item was returned by different queries of same project)
+    # That's why  we need an additional filter to hide duplicates (we will return only latest item from all items with
+    # same external_id/source)
+    # TODO: create a better solution for duplicate item, after POC is presented
+    #   see https://github.com/projectbenyehuda/sara/issues/13#issuecomment-1310482546
+    ResponseItem.
+      where(project_id: self.id).
+      where(favorite: true).
+      where(
+        <<~sql
+          not exists (
+            select 1 from
+              response_items ri
+            where
+              ri.source = response_items.source
+              and ri.external_id = response_items.external_id
+              and ri.project_id = response_items.project_id
+              and ri.id > response_items.id
+          )
+        sql
+      )
+  end
 end

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -1,6 +1,6 @@
 class Query < ApplicationRecord
   belongs_to :project, inverse_of: :queries
-  has_many :response_items, inverse_of: :query, dependent: :destroy
+  has_many :response_items, inverse_of: :query
 
   validates :text, presence: true
 end

--- a/app/models/response_item.rb
+++ b/app/models/response_item.rb
@@ -1,4 +1,7 @@
 class ResponseItem < ApplicationRecord
+  # We need a link for project, to keep favorite items available if parent query will be deleted
+  # see https://github.com/projectbenyehuda/sara/issues/13#issuecomment-1310482546
+  belongs_to :project, inverse_of: :response_items
   belongs_to :query, inverse_of: :response_items
 
   enum source: {
@@ -19,10 +22,11 @@ class ResponseItem < ApplicationRecord
     unknown: 7
   }, _prefix: true
 
-  validates_presence_of :query, :source, :media_type, :url, :index
+  validates_presence_of :source, :media_type, :url, :index
 
   scope :without_ignored, -> {
-    where(<<~sql.squish
+    where(
+      <<~SQL.squish
         not exists (
           select 1 from
             ignored_items i
@@ -32,7 +36,7 @@ class ResponseItem < ApplicationRecord
             and i.external_id = response_items.external_id
             and i.source = response_items.source
         )
-      sql
+      SQL
     )
   }
 end

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -11,6 +11,7 @@ class SearchService < ApplicationService
         query.response_items.where(source: source).delete_all
         items.each_with_index do |item, index|
           Rails.logger.error "DBG: can't create response item for #{item.url}!" unless query.response_items.create(
+            project: query.project,
             source: source,
             index: index,
             title: item.title[0..100],
@@ -23,7 +24,6 @@ class SearchService < ApplicationService
             normalized_year: item.normalized_year,
             external_id: item.external_id
           )
-          
         end
       end
     end

--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -18,9 +18,13 @@
     %th= t('activerecord.attributes.default.created_at')
     %th= t('activerecord.attributes.query.text')
     %th= t('.responses_quantity')
+    %th
   %tbody
     - @queries.each do |q|
       %tr
         %td= q.created_at
         %td= link_to q.text, q
         %td= q.responses_quantity
+        %td
+          = button_to t('.destroy_query'), "/queries/#{q.id}", method: :delete, class: 'btn btn-danger'
+

--- a/app/views/queries/show.html.haml
+++ b/app/views/queries/show.html.haml
@@ -162,7 +162,8 @@
                         %img{src: item.thumbnail_url}
                     .result-texts
                       - if item.title.present?
-                        %b= item.title
+                        %b
+                          = link_to item.title, item.url
                         %br
                       %p= item.text
                     %a.by-icon-v02.fav{:href => "#"} !

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,7 @@ en:
       responses_quantity: Responses Quantity
       create_new: New Search
       run: Run!
+      destroy_query: Destroy Query
   queries:
     show:
       header: "Found results for query: '%{query_text}'"
@@ -32,6 +33,8 @@ en:
       by_type: לפי סוג פריט
       flat_list: רשימה שטוחה
       summary_by_type: תמצית תוצאות לפי סוג פריט
+    destroy:
+      success: "Query destroyed"
   databases: מאגרי מידע
   data_items: פריטי מידע
   about_8_million: כ־8 מליון

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -45,6 +45,7 @@ he:
       create_new: חיפוש חדש
       run: חפש!
       stored_queries: חיפושים שמורים
+      destroy_query: Destroy Query
   queries:
     show:
       header: "להלן התוצאות עבור החיפוש: '%{query_text}'"
@@ -56,6 +57,8 @@ he:
       by_type: לפי סוג פריט
       flat_list: רשימה שטוחה
       summary_by_type: תמצית תוצאות לפי סוג פריט
+    destroy:
+      success: "Query destroyed"
   databases: מאגרי מידע
   data_items: פריטי מידע
   about_8_million: כ־8 מיליון

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   match 'welcome/suggest', as: 'suggest', via: [:get, :post]
   match 'welcome/search_disambig', as: 'search_disambig', via: [:get, :post]
 
-  resources :queries, only: [:show] do
+  resources :queries, only: [:show, :destroy] do
     member do
       get 'show'
       post 'show'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,12 +17,20 @@ Rails.application.routes.draw do
       post 'show'
     end
   end
+
   resources :projects, except: [:new] do
     resources :queries, only: [:create]
     resources :ignored_items, only: [:create]
   end
 
   resources :ignored_items, only: [:destroy]
+
+  resources :response_items, only: [] do
+    member do
+      post :toggle_favorite
+    end
+  end
+
   resources :timelines, only: :index do
     collection do
       get :data

--- a/db/migrate/20221110181948_add_favorite_to_response_items.rb
+++ b/db/migrate/20221110181948_add_favorite_to_response_items.rb
@@ -1,0 +1,5 @@
+class AddFavoriteToResponseItems < ActiveRecord::Migration[7.0]
+  def change
+    add_column :response_items, :favorite, :boolean, null: false, default: false
+  end
+end

--- a/db/migrate/20221110182038_add_project_id_to_response_items.rb
+++ b/db/migrate/20221110182038_add_project_id_to_response_items.rb
@@ -1,0 +1,7 @@
+class AddProjectIdToResponseItems < ActiveRecord::Migration[7.0]
+  def change
+    add_belongs_to :response_items, :project, index: true, foreign_key: true
+    execute 'update response_items ri set project_id = (select project_id from queries q where q.id = ri.query_id)'
+    change_column_null :response_items, :project_id, false
+  end
+end

--- a/db/migrate/20221110182710_make_response_item_query_id_nullable.rb
+++ b/db/migrate/20221110182710_make_response_item_query_id_nullable.rb
@@ -1,0 +1,5 @@
+class MakeResponseItemQueryIdNullable < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :response_items, :query_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.0].define(version: 2022_11_20_164633) do
-  create_table "ignored_items", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+  create_table "ignored_items", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.bigint "project_id", null: false
     t.string "external_id", null: false
     t.integer "source", null: false
@@ -20,13 +20,13 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_20_164633) do
     t.index ["project_id"], name: "index_ignored_items_on_project_id"
   end
 
-  create_table "projects", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+  create_table "projects", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.string "title"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "queries", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+  create_table "queries", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.string "text", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -34,7 +34,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_20_164633) do
     t.index ["project_id"], name: "index_queries_on_project_id"
   end
 
-  create_table "response_items", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+  create_table "response_items", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.bigint "query_id"
     t.integer "source", null: false
     t.integer "media_type", null: false
@@ -47,12 +47,16 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_20_164633) do
     t.datetime "updated_at", null: false
     t.string "external_id", null: false
     t.integer "index", null: false
+    t.boolean "favorite", default: false, null: false
+    t.bigint "project_id", null: false
     t.string "item_date"
     t.integer "normalized_year"
+    t.index ["project_id"], name: "index_response_items_on_project_id"
     t.index ["query_id"], name: "index_response_items_on_query_id"
   end
 
   add_foreign_key "ignored_items", "projects"
   add_foreign_key "queries", "projects"
+  add_foreign_key "response_items", "projects"
   add_foreign_key "response_items", "queries"
 end

--- a/spec/controllers/queries_controller_spec.rb
+++ b/spec/controllers/queries_controller_spec.rb
@@ -2,16 +2,13 @@ require 'rails_helper'
 
 describe QueriesController do
   describe 'Collection Actions' do
-    let(:project) { create(:project) }
-    before do
-      create_list(:query, 5, project: project)
-    end
+    let!(:project) { create(:project) }
 
     describe '#create' do
       subject(:call) { post :create, params: { project_id: project.id, query: { text: 'New Query' } } }
 
       before do
-        expect_any_instance_of(Search::PbySearchProvider).to receive(:call).and_return(build_list(:search_response_item, 5))
+        expect_any_instance_of(Search::PbySearchProvider).to receive(:call).and_return(build_list(:search_response_item, 6))
         expect_any_instance_of(Search::NliSearchProvider).to receive(:call).and_return(build_list(:search_response_item, 3))
       end
 
@@ -20,7 +17,7 @@ describe QueriesController do
         q = Query.order(id: :desc).first
 
         expect(q).to have_attributes(text: 'New Query')
-        expect(q.response_items.source_pby.count).to eq 5
+        expect(q.response_items.source_pby.count).to eq 6
         expect(q.response_items.source_nli.count).to eq 3
       end
     end

--- a/spec/controllers/response_items_controller_spec.rb
+++ b/spec/controllers/response_items_controller_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+describe ResponseItemsController do
+  describe '#toggle_favorite' do
+    let(:source) { :pby }
+    let(:external_id) { '12345' }
+
+    let!(:project) { create(:project) }
+    let!(:first_item) do
+      create(
+        :response_item,
+        project: project,
+        query: project.queries[0],
+        source: source,
+        external_id: external_id,
+        favorite: favorite
+      )
+    end
+
+    let!(:second_item) do
+      create(
+        :response_item,
+        project: project,
+        query: project.queries[1],
+        source: source,
+        external_id: external_id,
+        favorite: favorite
+      )
+    end
+
+    let!(:other_project) { create(:project) }
+
+    let!(:other_item) do
+      create(
+        :response_item,
+        project: other_project,
+        query: project.queries[0],
+        source: source,
+        external_id: external_id,
+        favorite: favorite
+      )
+    end
+
+    subject (:call) { post :toggle_favorite, params: { id: first_item.id, value: !favorite } }
+
+    context 'when we mark item as favorite' do
+      let(:favorite) { false }
+
+      it 'updates all items with given source/external_id withing single project' do
+        expect { call }.to change { ResponseItem.where(favorite: true).count }.by(2)
+        expect(first_item.reload.favorite).to be true
+        expect(second_item.reload.favorite).to be true
+        expect(other_item.reload.favorite).to be false
+      end
+    end
+
+    context 'when we unmark item as favorite' do
+      let(:favorite) { true }
+
+      it 'updates all items with given source/external_id withing single project' do
+        expect { call }.to change { ResponseItem.where(favorite: true).count }.by(-2)
+        expect(first_item.reload.favorite).to be false
+        expect(second_item.reload.favorite).to be false
+        expect(other_item.reload.favorite).to be true
+      end
+    end
+  end
+end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -2,7 +2,14 @@ FactoryBot.define do
   factory :project do
     title { Faker::Book.title }
 
-    queries { build_list(:query, 3, project: nil) }
+    transient do
+      queries_count { 3 }
+    end
+
     ignored_items { build_list(:ignored_item, 2, project: nil) }
+
+    after(:build) do |project, evaluator|
+      project.queries = build_list(:query, evaluator.queries_count, project: project)
+    end
   end
 end

--- a/spec/factories/queries.rb
+++ b/spec/factories/queries.rb
@@ -1,7 +1,14 @@
 FactoryBot.define do
   factory :query do
+    transient do
+      response_items_count { 5 }
+    end
+
     project
     text { Faker::Name.name }
-    response_items { build_list(:response_item, 5, query: nil) }
+
+    after(:build) do |query, evaluator|
+      query.response_items = build_list(:response_item, evaluator.response_items_count, project: query.project, query: query)
+    end
   end
 end

--- a/spec/factories/response_items.rb
+++ b/spec/factories/response_items.rb
@@ -1,10 +1,13 @@
 FactoryBot.define do
+  sequence :response_item_index
+
   factory :response_item do
     query
+    project { query&.project }
     source { ResponseItem.sources.keys.sample }
     external_id { Faker::Internet.url }
     media_type { ResponseItem.media_types.keys.sample }
-    index { query.present? ? (query.response_items.map(&:index).max || 0) + 1 : 1 }
+    index { generate :response_item_index }
     url { Faker::Internet.url }
     thumbnail_url { Faker::Internet.url }
     title { Faker::Book.title }

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -1,5 +1,58 @@
 require 'rails_helper'
 
 describe Project do
+  describe '.favorite_items' do
+    let!(:project) { create(:project) }
 
+    # this one should be ignored, because second item has same external_id and created later
+    let!(:first_item) do
+      create(
+        :response_item,
+        project: project,
+        query: project.queries[0],
+        source: :pby,
+        external_id: '12345',
+        favorite: true
+      )
+    end
+
+    let!(:second_item) do
+      create(
+        :response_item,
+        project: project,
+        query: project.queries[1],
+        source: :pby,
+        external_id: '12345',
+        favorite: true
+      )
+    end
+
+    let!(:third_item) do
+      create(
+        :response_item,
+        project: project,
+        query: project.queries[0],
+        source: :nli,
+        external_id: 'ABC',
+        favorite: true
+      )
+    end
+
+    # adding second project with favorite item to ensure it will not be returned
+    let!(:other_project) { create :project }
+    let!(:other_item) do
+      create(
+        :response_item,
+        project: other_project,
+        query: other_project.queries[0],
+        source: :nli,
+        external_id: 'OTHER',
+        favorite: true
+      )
+    end
+
+    it 'returns all favorite items from project, but excludes duplicating items' do
+      expect(project.favorite_items.pluck(:id)).to match_array [second_item.id, third_item.id]
+    end
+  end
 end


### PR DESCRIPTION
Implemented Favorite Items functionality.
Added favorite and project_id columns to response_items table.

Implemented endpoint to toggle favorite flag on items

Added Project.favorite_items scope to return response items without duplicates (to be used on favorite items view)
Implemented destroy query functionality. It keeps favorite items in project (sets query_id to null), but keeps project_id.