### PR TITLE
NLI fetch. External_ID length.

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -4,3 +4,5 @@ S3_ACCESS_KEY_ID=<set value in .env.development.local file>
 S3_SECRET_ACCESS_KEY=<set value in .env.development.local file>
 S3_STORAGE_BUCKET=<set value in .env.development.local file>
 PBY_API_KEY=<set value in .env.development.local file>
+PBY_MAX_RESULTS=100
+NLI_MAX_RESULTS=100

--- a/app/services/search/nli_search_provider.rb
+++ b/app/services/search/nli_search_provider.rb
@@ -5,38 +5,41 @@ module Search
     NLI_API_KEY = ENV['NLI_API_KEY']
     NLI_SEARCH_API_URL = 'https://api.nli.org.il/openlibrary/search'
 
+    # Max number of result to be fetched from NLI per query
+    # current implementation assumes its value to be a multiple of page size, otherwise it can return a bit more items
+    NLI_MAX_RESULTS = ENV['NLI_MAX_RESULTS'].to_i || 200
+
     def call(query)
+      result = []
       # see https://www.nli.org.il/en/research-and-teach/open-library/search-api
       begin
-        response = RestClient::Request.execute(
-          method: :get,
-          url: NLI_SEARCH_API_URL,
-          verify_ssl: false,
-          headers: {
-            params: {
-              api_key: NLI_API_KEY,
-              query: "any,contains,#{query}&availability_type=online_and_api_access"
-            },
-            content_type: :json
-          }
-        )
-        JSON.parse(response).map do |item|
-          Search::ResponseItem.new(
-            url: item['@id'].sub('https://www.nli.org.il/en/','https://www.nli.org.il/he/'),
-            thumbnail_url: property_value(item, 'thumbnail'),
-            external_id: property_value(item, 'recordid'),
-            title: "#{property_value(item, 'creator')} / #{property_value(item, 'title')}",
-            media_type: media_type_from_nli_type(property_value(item, 'type')),
-            media_url: property_value(item, 'download'),
-            text: property_value(item, 'format'),
-            item_date: property_value(item, 'date'),
-            normalized_year: normalize_year(property_value(item, 'date'))
-          )
+        # getting total number of records
+        response = query_nli(query, count_mode: true)
+        total = [JSON.parse(response)['countInfos']['total'], NLI_MAX_RESULTS].min
+
+        page = 1 # page index starts from 1
+        while result.size < total do
+          response = query_nli(query, { result_page: page } )
+          result += JSON.parse(response).map do |item|
+            Search::ResponseItem.new(
+              url: item['@id'].sub('https://www.nli.org.il/en/','https://www.nli.org.il/he/'),
+              thumbnail_url: property_value(item, 'thumbnail'),
+              external_id: property_value(item, 'recordid'),
+              title: "#{property_value(item, 'creator')} / #{property_value(item, 'title')}",
+              media_type: media_type_from_nli_type(property_value(item, 'type')),
+              media_url: property_value(item, 'download'),
+              text: property_value(item, 'format'),
+              item_date: property_value(item, 'date'),
+              normalized_year: normalize_year(property_value(item, 'date'))
+            )
+          end
+          page += 1
         end
       rescue RestClient::ExceptionWithResponse => error
+        # TODO: add reporting with a service like Rollbar or Sentry
         Rails.logger.error("NLI search failed: #{error.message}")
-        return []
       end
+      return result
     end
 
     def source
@@ -44,6 +47,22 @@ module Search
     end
 
     private
+
+    def query_nli(query, additional_params)
+      RestClient::Request.execute(
+        method: :get,
+        url: NLI_SEARCH_API_URL,
+        verify_ssl: false,
+        headers: {
+          params: {
+            api_key: NLI_API_KEY,
+            query: "any,contains,#{query}&availability_type=online_and_api_access"
+          }.merge(additional_params),
+          content_type: :json
+        }
+      )
+    end
+
     def property_value(item, property)
       val = item["http://purl.org/dc/elements/1.1/#{property}"]&.first
       return val.present? ? val['@value'] : nil

--- a/db/migrate/20221123130440_make_external_id_longer.rb
+++ b/db/migrate/20221123130440_make_external_id_longer.rb
@@ -1,0 +1,5 @@
+class MakeExternalIdLonger < ActiveRecord::Migration[7.0]
+  def change
+    change_column :response_items, :external_id, :string, limit: 2048
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_20_164633) do
-  create_table "ignored_items", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+ActiveRecord::Schema[7.0].define(version: 2022_11_23_130440) do
+  create_table "ignored_items", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.bigint "project_id", null: false
     t.string "external_id", null: false
     t.integer "source", null: false
@@ -20,13 +20,13 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_20_164633) do
     t.index ["project_id"], name: "index_ignored_items_on_project_id"
   end
 
-  create_table "projects", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+  create_table "projects", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.string "title"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "queries", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+  create_table "queries", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.string "text", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -34,7 +34,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_20_164633) do
     t.index ["project_id"], name: "index_queries_on_project_id"
   end
 
-  create_table "response_items", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+  create_table "response_items", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.bigint "query_id"
     t.integer "source", null: false
     t.integer "media_type", null: false
@@ -45,12 +45,12 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_20_164633) do
     t.text "text"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "external_id", null: false
+    t.string "external_id", limit: 2048, null: false
     t.integer "index", null: false
-    t.string "item_date"
-    t.integer "normalized_year"
     t.boolean "favorite", default: false, null: false
     t.bigint "project_id", null: false
+    t.string "item_date"
+    t.integer "normalized_year"
     t.index ["project_id"], name: "index_response_items_on_project_id"
     t.index ["query_id"], name: "index_response_items_on_query_id"
   end


### PR DESCRIPTION
Added paginated fetch for NLI provider (previously it only fetched first page of results).

Added two constants configurable from ENV variables: NLI_MAX_RESULTS and PBY_MAX_RESULTS to limit number of rows fetched from each source. If not specified they defaults to 200. In dev environment it is set to 100 (you can override in .env.development.local file)

Also it fixes bug occured when Commons search provider returned external_id with too long value (it uses URL as an external_id). Increased length of response_items.external_id to 2048