### PR TITLE
Added Google Maps to search_disambiq page

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,8 +1,15 @@
+# This file contains default settings for development environment assuming docker is used.
+# It misses some sensitive data like API keys, such vars are listed here for reference with empty values.
+# Don't edit this file to fill or change them, instead you should create a new .env.development.local file and
+# add/edit configuration settings in it.
+
 DATABASE_URL=mysql2://root:mysql@127.0.0.1:3306/sara_development
 MEMCACHE_SERVERS=127.0.0.1:11211
-S3_ACCESS_KEY_ID=<set value in .env.development.local file>
-S3_SECRET_ACCESS_KEY=<set value in .env.development.local file>
-S3_STORAGE_BUCKET=<set value in .env.development.local file>
-PBY_API_KEY=<set value in .env.development.local file>
+S3_ACCESS_KEY_ID=
+S3_SECRET_ACCESS_KEY=
+S3_STORAGE_BUCKET=
+GOOGLE_MAPS_JS_API_KEY=
+PBY_API_KEY=
 PBY_MAX_RESULTS=100
+NLI_API_KEY=
 NLI_MAX_RESULTS=100

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -2,6 +2,9 @@ require 'rest-client'
 
 MAX_WIKIDATA_RESULTS = 400
 
+PROP_COORDINATES = 'P625'
+PROP_INSTANCE_OF = 'P31'
+
 class WelcomeController < ApplicationController
   before_action :force_json, only: [:autocomplete_by_filter_tag, :query_by_filter]
 
@@ -100,17 +103,21 @@ class WelcomeController < ApplicationController
       images = {}
       print "."
       slice_ids = id_slice.join('|')
-      json2 = Rails.cache.fetch("entities_#{Digest::SHA256.hexdigest(slice_ids)}", expires_in: 12.hours) do
+      slice_items = Rails.cache.fetch("entities_#{Digest::SHA256.hexdigest(slice_ids)}", expires_in: 12.hours) do
         Rails.logger.debug "cache miss for entities for #{slice_ids}"
         RestClient.get 'https://www.wikidata.org/w/api.php', {params: {action: 'wbgetentities', ids: slice_ids, language: 'he', uselang: 'he', props: 'sitelinks|claims', format: 'json'}} do |resp, req, res, &block|
           if res.class == Net::HTTPOK
-            json2 = JSON.parse(resp.body)
+            JSON.parse(resp.body)
           end
         end
       end
-      json2['entities'].keys.each do |qid|
-        item = json2['entities'][qid]
-        @results[qid]['instance-of'] = item['claims']['P31'].map{|c| c['mainsnak']['datavalue']['value']['id']} if item['claims'].key?('P31')
+      slice_items['entities'].keys.each do |qid|
+        item = slice_items['entities'][qid]
+        claims = item['claims']
+
+        @results[qid]['instance-of'] = wikimedia_prop_values(claims, PROP_INSTANCE_OF)&.map{|c| c['id']}
+        @results[qid]['coordinates'] = first_prop_value(claims, PROP_COORDINATES, nil)
+
         @results[qid]['wikipedia_url'] = item['sitelinks']['hewiki'] ? 'https://he.wikipedia.org/wiki/'+item['sitelinks']['hewiki']['title'] : ''
         imagename = item['claims']['P18'] ? item['claims']['P18'][0]['mainsnak']['datavalue']['value'] : ''
         images['File:'+imagename] = qid unless imagename.empty?
@@ -163,7 +170,21 @@ class WelcomeController < ApplicationController
     @labels = get_labels_for_qids(qids.uniq)
     # TODO: also fetch Wikipedia article intros?
     @timeline_data = JSON.generate(prep_timeline_data(@results))
+
+    @map_markers = prep_map_markers(@results)
   end
+
+  def wikimedia_prop_values(claims, prop)
+    values = claims[prop]
+    return nil if values.nil?
+    return claims[prop].map { |item| item['mainsnak']['datavalue']['value']}
+  end
+
+  def first_prop_value(claims, prop, default_value = '')
+    values = wikimedia_prop_values(claims, prop)
+    return values.nil? || values.empty? ? default_value : values[0]
+  end
+
   def prep_timeline_data(results)
     timeline_data = []
     results.each do |qid, data|
@@ -176,6 +197,18 @@ class WelcomeController < ApplicationController
     end
     return timeline_data
   end
+
+  def prep_map_markers(items)
+    result = []
+    items.each do |qid, data|
+      coordinates = data['coordinates']
+      next if coordinates.blank?
+      result << coordinates.slice('latitude', 'longitude').merge(title: data[:label], icon: data['thumbnail'], qid: qid)
+    end
+
+    return result
+  end
+
   def compose_query(base_query)
     ret = base_query
     if params[:fromdate].present? || params[:todate].present?

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -8,6 +8,8 @@
     = csp_meta_tag
     = stylesheet_link_tag 'application', 'data-turbo-track': 'reload'
     = javascript_include_tag 'application', 'data-turbo-track': 'reload'
+    = yield :head
+
   %body{ align: :right, dir: :rtl, class: "#{controller_name}-#{action_name}" }
     = render partial: 'shared/top_bar'
     .top-element

--- a/app/views/welcome/search_disambig.html.haml
+++ b/app/views/welcome/search_disambig.html.haml
@@ -1,3 +1,7 @@
+= content_for :head do
+  %script{ src: "https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_MAPS_JS_API_KEY']}" }
+  %script{ src: "https://unpkg.com/@googlemaps/markerclusterer/dist/index.min.js" }
+
 %script{ type: 'text/javascript', charset:'utf-8', src: asset_url('histropedia-1.2.0.js')}
 %div#spinnerdiv{style: 'display: none; top: 50%; left: 50%;'}
   #floatingCirclesG
@@ -125,19 +129,26 @@
           #histropedia-timeline
         .map{style:'margin-top:121px;display:none;'}
           %h3= t(:display_map)
-
+          #map_container{ style: "height: 600px; width: 1024px;" }
 = form_for([Project.last, Query.new]) do |f|
   = f.hidden_field :text, class: 'form-control', id: 'search_q'
   = f.submit t('projects.show.run'), style: 'display:none'
 
 :javascript
   function startModal(id) {
-      $("body").prepend("<div id='PopupMask' style='position:fixed;width:100%;height:100%;z-index:10;background-color:gray;'></div>");
-      $("#PopupMask").css('opacity', 0.5);
-      $("#"+id).css( "z-index" , 11 );
-      $("#"+id).css( "position" , "fixed" );
-      $("#"+id).css( "display" , "block" );
+    $("body").prepend("<div id='PopupMask' style='position:fixed;width:100%;height:100%;z-index:10;background-color:gray;'></div>");
+    $("#PopupMask").css('opacity', 0.5);
+    $("#"+id).css( "z-index" , 11 );
+    $("#"+id).css( "position" , "fixed" );
+    $("#"+id).css( "display" , "block" );
   }
+
+  function selectItem(qid, search_q) {
+    $('#qid').val(qid);
+    $('#search_q').val(search_q);
+    $('#search-subject-results-button').removeClass('disabled');
+  };
+
 
   $(document).ready(function() {
     $('.result-item').click(function(e) {
@@ -199,34 +210,55 @@
       $('.map').hide();
     });
 
-
-    // prep timeline
-    const container = document.getElementById('histropedia-timeline');
-    if (container != null) {
-      data = JSON.parse("#{j(raw @timeline_data)}");
-      let min = null;
-      let minVal = Infinity;
-      data.forEach((item) => {
-        if(item.from != null) {
-          const val = item.from.year * 10000; // + item.from.month * 100 + item.from.day;
-          if (val < minVal) {
-            minVal = val;
-            min = item;
+    try {
+      // prep timeline
+      const container = document.getElementById('histropedia-timeline');
+      if (container != null) {
+        const data = JSON.parse("#{j(raw @timeline_data)}");
+        let min = null;
+        let minVal = Infinity;
+        data.forEach((item) => {
+          if(item.from != null) {
+            const val = item.from.year * 10000; // + item.from.month * 100 + item.from.day;
+            if (val < minVal) {
+              minVal = val;
+              min = item;
+            }
           }
-        }
-      });
-      const timeline = new Histropedia.Timeline(container, { height: 700, article: {distanceToMainLine: 100}, 
-        initialDate: (min ? min.from : null),
-        article: {autoStacking: {topGap: 0, fitToHeight: false}},
-        onArticleClick: function(article) {
-          $('#qid').val(article.id);
-          $('#search_q').val(article.title);
-          $('#search-subject-results-button').removeClass('disabled');
-        },
-        onArticleDoubleClick: function(article) {
-        }
-      });
-      timeline.load(data);
+        });
+        const timeline = new Histropedia.Timeline(container, { height: 700, article: {distanceToMainLine: 100},
+          initialDate: (min ? min.from : 19800000),
+          article: {autoStacking: {topGap: 0, fitToHeight: false}},
+          onArticleClick: function(article) { selectItem(article.id, article.title); },
+          onArticleDoubleClick: function(article) {
+          }
+        });
+        timeline.load(data);
+      }
+    } catch (e) {
+      console.error(e);
     }
+
+    const map = new google.maps.Map(
+        document.getElementById('map_container'),
+        {
+          center: { lat: 31.771959, lng: 35.217018 }, /* coordinates of Jerusalem */
+          zoom: 2
+        }
+    );
+
+    const markers = [];
+
+    #{raw @map_markers.to_json}.forEach(item => {
+      const marker = new google.maps.Marker({
+        position: { lat: item['latitude'], lng: item['longitude'] },
+        map,
+        title: item['title'],
+        icon: item['icon']
+      });
+      marker.addListener("click", () => { selectItem(item['qid'], item['title']); });
+      markers.push(marker);
+    });
+
+    new markerClusterer.MarkerClusterer({ markers, map });
   });
-  


### PR DESCRIPTION
Added google maps widget to 'Map' tab of search_disambig page.
It works, and allows to select items by clicking on them. But I did not found (yet) a  way to indicate wich item is selected on the map. Will dig into it further.

To make it work you'll need to set a new env variable GOOGLE_MAPS_JS_API_KEY
for development env simply add it to .env.development.local

in production, you'll need to modify startup script to sets its value.